### PR TITLE
Fix licence bootstrap error

### DIFF
--- a/license.am
+++ b/license.am
@@ -2,7 +2,9 @@
 # Embedded license header support
 #---------------------------------
 
+CLEANFILES    =
 CLEANFILES    += .license.stamp
+BUILT_SOURCES =
 BUILT_SOURCES += .license.stamp
 
 .license.stamp: $(top_builddir)/LICENSE


### PR DESCRIPTION
This fixes an error with autoreconf that MK bumped into.  Thought I'd spin up a patch for you.
