### PR TITLE
Fix make distcheck when Doxygen is unavailable

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -15,11 +15,13 @@ EXTRA_DIST  += build-aux/update_license.pl
 EXTRA_DIST  += m4/gnulib-cache.m4
 
 dist-hook: docs
-	: # Include generated documentation in the dist tarball
-	cp -r $(top_builddir)/docs $(top_distdir)
+	: # Include generated documentation in the dist tarball if present
+	if test -d $(top_builddir)/docs; then \
+	    cp -r $(top_builddir)/docs $(top_distdir); \
+	fi
 	: # Eliminate .git and .svn directories in dist tarball
-	find $(distdir)/ -name '.svn' -type d -exec rm {} \;
-	find $(distdir)/ -name '.git' -type d -exec rm {} \;
+	-find $(distdir)/ -name '.svn' -type d -prune -exec rm -rf {} \;
+	-find $(distdir)/ -name '.git' -type d -prune -exec rm -rf {} \;
 
 # Tools in the auxillary directory
 AUX_DIST  = build-aux/install-sh

--- a/doxygen/doxygen.am
+++ b/doxygen/doxygen.am
@@ -156,4 +156,12 @@ DX_CLEANFILES = \
     $(DX_CLEAN_PDF) \
     $(DX_CLEAN_LATEX)
 
-endif DX_COND_doc
+else
+
+## Stub targets when Doxygen documentation is disabled
+.PHONY: doxygen-run doxygen-doc
+
+doxygen-run:
+doxygen-doc:
+
+endif


### PR DESCRIPTION
Fix make distcheck when Doxygen is unavailable

Stub doxygen-run and doxygen-doc targets when DX_COND_doc is false,
so that dependent targets like dist-hook don't fail with "No rule to make target 'doxygen-run'"

 Also make dist-hook more robust by checking if the docs directory exists before copying it.