### PR TITLE
Remove RCS $Id$ keywords from source files

### DIFF
--- a/apps/esio_bench.c
+++ b/apps/esio_bench.c
@@ -23,7 +23,6 @@
 // along with ESIO.  If not, see <http://www.gnu.org/licenses/>.
 //
 //-----------------------------------------------------------------------el-
-// $Id$
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"

--- a/apps/esio_rename.c
+++ b/apps/esio_rename.c
@@ -23,7 +23,6 @@
 // along with ESIO.  If not, see <http://www.gnu.org/licenses/>.
 //
 //-----------------------------------------------------------------------el-
-// $Id$
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"

--- a/apps/mpi_argp.c
+++ b/apps/mpi_argp.c
@@ -23,7 +23,6 @@
 // along with ESIO.  If not, see <http://www.gnu.org/licenses/>.
 //
 //-----------------------------------------------------------------------el-
-// $Id$
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"

--- a/apps/mpi_argp.h
+++ b/apps/mpi_argp.h
@@ -23,7 +23,6 @@
 // along with ESIO.  If not, see <http://www.gnu.org/licenses/>.
 //
 //-----------------------------------------------------------------------el-
-// $Id$
 
 #ifndef ESIO_MPI_ARGP_H__
 #define ESIO_MPI_ARGP_H__

--- a/apps/p3dfft_like.F90
+++ b/apps/p3dfft_like.F90
@@ -23,7 +23,6 @@
 !! along with ESIO.  If not, see <http://www.gnu.org/licenses/>.
 !!
 !!-----------------------------------------------------------------------el-
-!! $Id$
 
 !> Program designed to 'chunk' a field into multiple pieces so we can
 !! load it up into an HDF-like storage.  Ideally, field should be similar

--- a/apps/p3dfft_like_header.F90
+++ b/apps/p3dfft_like_header.F90
@@ -23,7 +23,6 @@
 !! along with ESIO.  If not, see <http://www.gnu.org/licenses/>.
 !!
 !!-----------------------------------------------------------------------el-
-!! $Id$
 
 !> Module that contains the problem in use.  Parallel problem
 !! decomposition based upon P3DFFT's logic but may differ in

--- a/bootstrap
+++ b/bootstrap
@@ -1,3 +1,2 @@
 #! /bin/sh
-# $Id$
 autoreconf -v -i || exit 1

--- a/build-aux/sfmakedepend.pl
+++ b/build-aux/sfmakedepend.pl
@@ -1,6 +1,5 @@
 #!/usr/bin/env perl
 #
-# $Id$
 #
 #-------------------------------------------------------------------
 # July 2010 - koomie modified from a starting version found online

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,6 @@ dnl ----------------------------------------------------
 dnl Package name, release number, description, and URL
 dnl ----------------------------------------------------
 AC_INIT([ESIO], [0.2.0], [rhys.ulerich@gmail.com], [esio])
-AC_REVISION([$Id$])
 PACKAGE_DESCRIPTION="ExaScale IO library for turbulence simulation restart files"
 AC_SUBST([PACKAGE_DESCRIPTION])
 PACKAGE_URL="http://github.com/RhysU/ESIO"

--- a/esio/chunksize.c
+++ b/esio/chunksize.c
@@ -23,7 +23,6 @@
 // along with ESIO.  If not, see <http://www.gnu.org/licenses/>.
 //
 //-----------------------------------------------------------------------el-
-// $Id$
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"

--- a/esio/chunksize.h
+++ b/esio/chunksize.h
@@ -23,7 +23,6 @@
 // along with ESIO.  If not, see <http://www.gnu.org/licenses/>.
 //
 //-----------------------------------------------------------------------el-
-// $Id$
 
 #ifndef ESIO_CHUNKSIZE_H
 #define ESIO_CHUNKSIZE_H

--- a/esio/error.c
+++ b/esio/error.c
@@ -23,7 +23,6 @@
 // along with ESIO.  If not, see <http://www.gnu.org/licenses/>.
 //
 //-----------------------------------------------------------------------el-
-// $Id$
 
 /******************************************************************************
  * Functionality adopted from the GNU Scientific Library.

--- a/esio/error.h
+++ b/esio/error.h
@@ -23,7 +23,6 @@
 // along with ESIO.  If not, see <http://www.gnu.org/licenses/>.
 //
 //-----------------------------------------------------------------------el-
-// $Id$
 
 #ifndef ESIO_ERROR_H
 #define ESIO_ERROR_H

--- a/esio/esio.F90
+++ b/esio/esio.F90
@@ -23,7 +23,6 @@
 !! along with ESIO.  If not, see <http://www.gnu.org/licenses/>.
 !!
 !!-----------------------------------------------------------------------el-
-!! $Id$
 
 ! TODO Allow Fortran to detect invalid handle before other failure
 ! TODO Disable error handling when ierr is present??

--- a/esio/esio.c
+++ b/esio/esio.c
@@ -23,7 +23,6 @@
 // along with ESIO.  If not, see <http://www.gnu.org/licenses/>.
 //
 //-----------------------------------------------------------------------el-
-// $Id$
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"

--- a/esio/esio.h
+++ b/esio/esio.h
@@ -23,7 +23,6 @@
 // along with ESIO.  If not, see <http://www.gnu.org/licenses/>.
 //
 //-----------------------------------------------------------------------el-
-// $Id$
 
 #ifndef ESIO_ESIO_H
 #define ESIO_ESIO_H

--- a/esio/esio_c_binding.F90
+++ b/esio/esio_c_binding.F90
@@ -23,7 +23,6 @@
 !! along with ESIO.  If not, see <http://www.gnu.org/licenses/>.
 !!
 !!-----------------------------------------------------------------------el-
-!! $Id$
 
 !> \file
 !! Provides utilities to simplify Fortran-to-C interfacing within ESIO.

--- a/esio/file-copy.c
+++ b/esio/file-copy.c
@@ -23,7 +23,6 @@
 // along with ESIO.  If not, see <http://www.gnu.org/licenses/>.
 //
 //-----------------------------------------------------------------------el-
-// $Id$
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"

--- a/esio/file-copy.h
+++ b/esio/file-copy.h
@@ -23,7 +23,6 @@
 // along with ESIO.  If not, see <http://www.gnu.org/licenses/>.
 //
 //-----------------------------------------------------------------------el-
-// $Id$
 
 #ifndef ESIO_FILE_COPY_H
 #define ESIO_FILE_COPY_H

--- a/esio/h5utils.c
+++ b/esio/h5utils.c
@@ -23,7 +23,6 @@
 // along with ESIO.  If not, see <http://www.gnu.org/licenses/>.
 //
 //-----------------------------------------------------------------------el-
-// $Id$
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"

--- a/esio/h5utils.h
+++ b/esio/h5utils.h
@@ -23,7 +23,6 @@
 // along with ESIO.  If not, see <http://www.gnu.org/licenses/>.
 //
 //-----------------------------------------------------------------------el-
-// $Id$
 
 #ifndef ESIO_H5UTILS_H
 #define ESIO_H5UTILS_H

--- a/esio/layout.c
+++ b/esio/layout.c
@@ -23,7 +23,6 @@
 // along with ESIO.  If not, see <http://www.gnu.org/licenses/>.
 //
 //-----------------------------------------------------------------------el-
-// $Id$
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"

--- a/esio/layout.h
+++ b/esio/layout.h
@@ -23,7 +23,6 @@
 // along with ESIO.  If not, see <http://www.gnu.org/licenses/>.
 //
 //-----------------------------------------------------------------------el-
-// $Id$
 
 #ifndef ESIO_LAYOUT_H
 #define ESIO_LAYOUT_H

--- a/esio/metadata.c
+++ b/esio/metadata.c
@@ -23,7 +23,6 @@
 // along with ESIO.  If not, see <http://www.gnu.org/licenses/>.
 //
 //-----------------------------------------------------------------------el-
-// $Id$
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"

--- a/esio/metadata.h
+++ b/esio/metadata.h
@@ -23,7 +23,6 @@
 // along with ESIO.  If not, see <http://www.gnu.org/licenses/>.
 //
 //-----------------------------------------------------------------------el-
-// $Id$
 
 #ifndef ESIO_METADATA_H
 #define ESIO_METADATA_H

--- a/esio/restart-rename.c
+++ b/esio/restart-rename.c
@@ -23,7 +23,6 @@
 // along with ESIO.  If not, see <http://www.gnu.org/licenses/>.
 //
 //-----------------------------------------------------------------------el-
-// $Id$
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"

--- a/esio/restart-rename.h
+++ b/esio/restart-rename.h
@@ -23,7 +23,6 @@
 // along with ESIO.  If not, see <http://www.gnu.org/licenses/>.
 //
 //-----------------------------------------------------------------------el-
-// $Id$
 
 #ifndef ESIO_RESTART_RENAME_H
 #define ESIO_RESTART_RENAME_H

--- a/esio/uri.c
+++ b/esio/uri.c
@@ -23,7 +23,6 @@
 // along with ESIO.  If not, see <http://www.gnu.org/licenses/>.
 //
 //-----------------------------------------------------------------------el-
-// $Id$
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"

--- a/esio/uri.h
+++ b/esio/uri.h
@@ -23,7 +23,6 @@
 // along with ESIO.  If not, see <http://www.gnu.org/licenses/>.
 //
 //-----------------------------------------------------------------------el-
-// $Id$
 
 #ifndef ESIO_URI_H
 #define ESIO_URI_H

--- a/esio/version.h.in
+++ b/esio/version.h.in
@@ -23,7 +23,6 @@
 // along with ESIO.  If not, see <http://www.gnu.org/licenses/>.
 //
 //-----------------------------------------------------------------------el-
-// $Id$
 
 #ifndef ESIO_VERSION_H
 #define ESIO_VERSION_H

--- a/esio/visibility.h
+++ b/esio/visibility.h
@@ -23,7 +23,6 @@
 // along with ESIO.  If not, see <http://www.gnu.org/licenses/>.
 //
 //-----------------------------------------------------------------------el-
-// $Id$
 
 #ifndef ESIO_VISIBILITY_H__
 #define ESIO_VISIBILITY_H__

--- a/esio/x-attribute.F90
+++ b/esio/x-attribute.F90
@@ -23,7 +23,6 @@
 !! along with ESIO.  If not, see <http://www.gnu.org/licenses/>.
 !!
 !!-----------------------------------------------------------------------el-
-!! $Id$
 
 ! Designed to be #included from esio.F90 within a subroutine declaration
 

--- a/esio/x-field.F90
+++ b/esio/x-field.F90
@@ -23,7 +23,6 @@
 !! along with ESIO.  If not, see <http://www.gnu.org/licenses/>.
 !!
 !!-----------------------------------------------------------------------el-
-!! $Id$
 
 ! Designed to be #included from esio.F90 within a subroutine declaration
 

--- a/esio/x-layout0.c
+++ b/esio/x-layout0.c
@@ -23,7 +23,6 @@
 // along with ESIO.  If not, see <http://www.gnu.org/licenses/>.
 //
 //-----------------------------------------------------------------------el-
-// $Id$
 
 // Designed to be #included from layout.c
 #if !defined(METHODNAME) || !defined(OPFUNC) || !defined(QUALIFIER)

--- a/esio/x-layout1.c
+++ b/esio/x-layout1.c
@@ -23,7 +23,6 @@
 // along with ESIO.  If not, see <http://www.gnu.org/licenses/>.
 //
 //-----------------------------------------------------------------------el-
-// $Id$
 
 // Designed to be #included from layout.c
 #if !defined(METHODNAME) || !defined(OPFUNC) || !defined(QUALIFIER)

--- a/esio/x-layout2.c
+++ b/esio/x-layout2.c
@@ -23,7 +23,6 @@
 // along with ESIO.  If not, see <http://www.gnu.org/licenses/>.
 //
 //-----------------------------------------------------------------------el-
-// $Id$
 
 // Designed to be #included from layout.c
 #if !defined(METHODNAME) || !defined(OPFUNC) || !defined(QUALIFIER)

--- a/esio/x-line.F90
+++ b/esio/x-line.F90
@@ -23,7 +23,6 @@
 !! along with ESIO.  If not, see <http://www.gnu.org/licenses/>.
 !!
 !!-----------------------------------------------------------------------el-
-!! $Id$
 
 ! Designed to be #included from esio.F90 within a subroutine declaration
 

--- a/esio/x-line.c
+++ b/esio/x-line.c
@@ -23,7 +23,6 @@
 // along with ESIO.  If not, see <http://www.gnu.org/licenses/>.
 //
 //-----------------------------------------------------------------------el-
-// $Id$
 
 // Designed to be #included from layout.c
 #if !defined(METHODNAME) || !defined(OPFUNC) || !defined(QUALIFIER)

--- a/esio/x-plane.F90
+++ b/esio/x-plane.F90
@@ -23,7 +23,6 @@
 !! along with ESIO.  If not, see <http://www.gnu.org/licenses/>.
 !!
 !!-----------------------------------------------------------------------el-
-!! $Id$
 
 ! Designed to be #included from esio.F90 within a subroutine declaration
 

--- a/esio/x-plane.c
+++ b/esio/x-plane.c
@@ -23,7 +23,6 @@
 // along with ESIO.  If not, see <http://www.gnu.org/licenses/>.
 //
 //-----------------------------------------------------------------------el-
-// $Id$
 
 // Designed to be #included from layout.c
 #if !defined(METHODNAME) || !defined(OPFUNC) || !defined(QUALIFIER)

--- a/m4/coverage.m4
+++ b/m4/coverage.m4
@@ -11,7 +11,6 @@
 #
 # LAST MODIFICATION
 #
-#   $Id$
 #
 # COPYLEFT
 #

--- a/tests/attribute_double.c
+++ b/tests/attribute_double.c
@@ -23,7 +23,6 @@
 // along with ESIO.  If not, see <http://www.gnu.org/licenses/>.
 //
 //-----------------------------------------------------------------------el-
-// $Id$
 
 #define TYPE              double
 #define AFFIX(name)       name ## _double

--- a/tests/attribute_float.c
+++ b/tests/attribute_float.c
@@ -23,7 +23,6 @@
 // along with ESIO.  If not, see <http://www.gnu.org/licenses/>.
 //
 //-----------------------------------------------------------------------el-
-// $Id$
 
 #define TYPE              float
 #define AFFIX(name)       name ## _float

--- a/tests/attribute_int.c
+++ b/tests/attribute_int.c
@@ -23,7 +23,6 @@
 // along with ESIO.  If not, see <http://www.gnu.org/licenses/>.
 //
 //-----------------------------------------------------------------------el-
-// $Id$
 
 #define TYPE              int
 #define AFFIX(name)       name ## _int

--- a/tests/attribute_int_f.F90
+++ b/tests/attribute_int_f.F90
@@ -23,7 +23,6 @@
 !! along with ESIO.  If not, see <http://www.gnu.org/licenses/>.
 !!
 !!-----------------------------------------------------------------------el-
-!! $Id$
 
 #include "testframework_assert.h"
 

--- a/tests/attribute_template.c
+++ b/tests/attribute_template.c
@@ -23,7 +23,6 @@
 // along with ESIO.  If not, see <http://www.gnu.org/licenses/>.
 //
 //-----------------------------------------------------------------------el-
-// $Id$
 
 #if    !defined(TYPE) \
     || !defined(AFFIX)

--- a/tests/basic.c
+++ b/tests/basic.c
@@ -23,7 +23,6 @@
 // along with ESIO.  If not, see <http://www.gnu.org/licenses/>.
 //
 //-----------------------------------------------------------------------el-
-// $Id$
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"

--- a/tests/basic_f.F90
+++ b/tests/basic_f.F90
@@ -23,7 +23,6 @@
 !! along with ESIO.  If not, see <http://www.gnu.org/licenses/>.
 !!
 !!-----------------------------------------------------------------------el-
-!! $Id$
 
 #include "testframework_assert.h"
 

--- a/tests/layout0_double.c
+++ b/tests/layout0_double.c
@@ -23,7 +23,6 @@
 // along with ESIO.  If not, see <http://www.gnu.org/licenses/>.
 //
 //-----------------------------------------------------------------------el-
-// $Id$
 
 #define REAL              double
 #define REAL_H5T          H5T_NATIVE_DOUBLE

--- a/tests/layout0_float.c
+++ b/tests/layout0_float.c
@@ -23,7 +23,6 @@
 // along with ESIO.  If not, see <http://www.gnu.org/licenses/>.
 //
 //-----------------------------------------------------------------------el-
-// $Id$
 
 #define REAL              float
 #define REAL_H5T          H5T_NATIVE_FLOAT

--- a/tests/layout0_int.c
+++ b/tests/layout0_int.c
@@ -23,7 +23,6 @@
 // along with ESIO.  If not, see <http://www.gnu.org/licenses/>.
 //
 //-----------------------------------------------------------------------el-
-// $Id$
 
 #define REAL              int
 #define REAL_H5T          H5T_NATIVE_INT

--- a/tests/layout0_int_f.F90
+++ b/tests/layout0_int_f.F90
@@ -23,7 +23,6 @@
 !! along with ESIO.  If not, see <http://www.gnu.org/licenses/>.
 !!
 !!-----------------------------------------------------------------------el-
-!! $Id$
 
 #include "testframework_assert.h"
 

--- a/tests/layout1_double.c
+++ b/tests/layout1_double.c
@@ -23,7 +23,6 @@
 // along with ESIO.  If not, see <http://www.gnu.org/licenses/>.
 //
 //-----------------------------------------------------------------------el-
-// $Id$
 
 #define REAL              double
 #define REAL_H5T          H5T_NATIVE_DOUBLE

--- a/tests/layout1_float.c
+++ b/tests/layout1_float.c
@@ -23,7 +23,6 @@
 // along with ESIO.  If not, see <http://www.gnu.org/licenses/>.
 //
 //-----------------------------------------------------------------------el-
-// $Id$
 
 #define REAL              float
 #define REAL_H5T          H5T_NATIVE_FLOAT

--- a/tests/layout1_int.c
+++ b/tests/layout1_int.c
@@ -23,7 +23,6 @@
 // along with ESIO.  If not, see <http://www.gnu.org/licenses/>.
 //
 //-----------------------------------------------------------------------el-
-// $Id$
 
 #define REAL              int
 #define REAL_H5T          H5T_NATIVE_INT

--- a/tests/layout2_double.c
+++ b/tests/layout2_double.c
@@ -23,7 +23,6 @@
 // along with ESIO.  If not, see <http://www.gnu.org/licenses/>.
 //
 //-----------------------------------------------------------------------el-
-// $Id$
 
 #define REAL              double
 #define REAL_H5T          H5T_NATIVE_DOUBLE

--- a/tests/layout2_float.c
+++ b/tests/layout2_float.c
@@ -23,7 +23,6 @@
 // along with ESIO.  If not, see <http://www.gnu.org/licenses/>.
 //
 //-----------------------------------------------------------------------el-
-// $Id$
 
 #define REAL              float
 #define REAL_H5T          H5T_NATIVE_FLOAT

--- a/tests/layout2_int.c
+++ b/tests/layout2_int.c
@@ -23,7 +23,6 @@
 // along with ESIO.  If not, see <http://www.gnu.org/licenses/>.
 //
 //-----------------------------------------------------------------------el-
-// $Id$
 
 #define REAL              int
 #define REAL_H5T          H5T_NATIVE_INT

--- a/tests/layout_template.c
+++ b/tests/layout_template.c
@@ -23,7 +23,6 @@
 // along with ESIO.  If not, see <http://www.gnu.org/licenses/>.
 //
 //-----------------------------------------------------------------------el-
-// $Id$
 
 #if    !defined(REAL) \
     || !defined(REAL_H5T) \

--- a/tests/line_double.c
+++ b/tests/line_double.c
@@ -23,7 +23,6 @@
 // along with ESIO.  If not, see <http://www.gnu.org/licenses/>.
 //
 //-----------------------------------------------------------------------el-
-// $Id$
 
 #define REAL              double
 #define REAL_H5T          H5T_NATIVE_DOUBLE

--- a/tests/line_float.c
+++ b/tests/line_float.c
@@ -23,7 +23,6 @@
 // along with ESIO.  If not, see <http://www.gnu.org/licenses/>.
 //
 //-----------------------------------------------------------------------el-
-// $Id$
 
 #define REAL              float
 #define REAL_H5T          H5T_NATIVE_FLOAT

--- a/tests/line_int.c
+++ b/tests/line_int.c
@@ -23,7 +23,6 @@
 // along with ESIO.  If not, see <http://www.gnu.org/licenses/>.
 //
 //-----------------------------------------------------------------------el-
-// $Id$
 
 #define REAL              int
 #define REAL_H5T          H5T_NATIVE_INT

--- a/tests/line_int_f.F90
+++ b/tests/line_int_f.F90
@@ -23,7 +23,6 @@
 !! along with ESIO.  If not, see <http://www.gnu.org/licenses/>.
 !!
 !!-----------------------------------------------------------------------el-
-!! $Id$
 
 #include "testframework_assert.h"
 

--- a/tests/line_template.c
+++ b/tests/line_template.c
@@ -23,7 +23,6 @@
 // along with ESIO.  If not, see <http://www.gnu.org/licenses/>.
 //
 //-----------------------------------------------------------------------el-
-// $Id$
 
 #if    !defined(REAL) \
     || !defined(REAL_H5T) \

--- a/tests/plane_double.c
+++ b/tests/plane_double.c
@@ -23,7 +23,6 @@
 // along with ESIO.  If not, see <http://www.gnu.org/licenses/>.
 //
 //-----------------------------------------------------------------------el-
-// $Id$
 
 #define REAL              double
 #define REAL_H5T          H5T_NATIVE_DOUBLE

--- a/tests/plane_float.c
+++ b/tests/plane_float.c
@@ -23,7 +23,6 @@
 // along with ESIO.  If not, see <http://www.gnu.org/licenses/>.
 //
 //-----------------------------------------------------------------------el-
-// $Id$
 
 #define REAL              float
 #define REAL_H5T          H5T_NATIVE_FLOAT

--- a/tests/plane_int.c
+++ b/tests/plane_int.c
@@ -23,7 +23,6 @@
 // along with ESIO.  If not, see <http://www.gnu.org/licenses/>.
 //
 //-----------------------------------------------------------------------el-
-// $Id$
 
 #define REAL              int
 #define REAL_H5T          H5T_NATIVE_INT

--- a/tests/plane_int_f.F90
+++ b/tests/plane_int_f.F90
@@ -23,7 +23,6 @@
 !! along with ESIO.  If not, see <http://www.gnu.org/licenses/>.
 !!
 !!-----------------------------------------------------------------------el-
-!! $Id$
 
 #include "testframework_assert.h"
 

--- a/tests/plane_template.c
+++ b/tests/plane_template.c
@@ -23,7 +23,6 @@
 // along with ESIO.  If not, see <http://www.gnu.org/licenses/>.
 //
 //-----------------------------------------------------------------------el-
-// $Id$
 
 #if    !defined(REAL) \
     || !defined(REAL_H5T) \

--- a/tests/restart_helpers.c
+++ b/tests/restart_helpers.c
@@ -23,7 +23,6 @@
 // along with ESIO.  If not, see <http://www.gnu.org/licenses/>.
 //
 //-----------------------------------------------------------------------el-
-// $Id$
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"

--- a/tests/sanity_f.F90
+++ b/tests/sanity_f.F90
@@ -23,7 +23,6 @@
 !! along with ESIO.  If not, see <http://www.gnu.org/licenses/>.
 !!
 !!-----------------------------------------------------------------------el-
-!! $Id$
 
 #include "testframework_assert.h"
 

--- a/tests/string.c
+++ b/tests/string.c
@@ -23,7 +23,6 @@
 // along with ESIO.  If not, see <http://www.gnu.org/licenses/>.
 //
 //-----------------------------------------------------------------------el-
-// $Id$
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"

--- a/tests/string_f.F90
+++ b/tests/string_f.F90
@@ -23,7 +23,6 @@
 !! along with ESIO.  If not, see <http://www.gnu.org/licenses/>.
 !!
 !!-----------------------------------------------------------------------el-
-!! $Id$
 
 #include "testframework_assert.h"
 

--- a/tests/testframework.F90
+++ b/tests/testframework.F90
@@ -23,7 +23,6 @@
 !! along with ESIO.  If not, see <http://www.gnu.org/licenses/>.
 !!
 !!-----------------------------------------------------------------------el-
-!! $Id$
 
 module testframework
 

--- a/tests/testutils.c
+++ b/tests/testutils.c
@@ -23,7 +23,6 @@
 // along with ESIO.  If not, see <http://www.gnu.org/licenses/>.
 //
 //-----------------------------------------------------------------------el-
-// $Id$
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"

--- a/tests/testutils.h
+++ b/tests/testutils.h
@@ -23,7 +23,6 @@
 // along with ESIO.  If not, see <http://www.gnu.org/licenses/>.
 //
 //-----------------------------------------------------------------------el-
-// $Id$
 
 /**
  * Create an output filename template suitable for use with mkstemp(3).

--- a/tests/uri_tests.c
+++ b/tests/uri_tests.c
@@ -23,7 +23,6 @@
 // along with ESIO.  If not, see <http://www.gnu.org/licenses/>.
 //
 //-----------------------------------------------------------------------el-
-// $Id$
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"


### PR DESCRIPTION
Removes all RCS `$Id$` keywords throughout the project. 