### PR TITLE
Fix compiler warnings and improve code quality

### DIFF
--- a/apps/esio_bench.c
+++ b/apps/esio_bench.c
@@ -560,6 +560,11 @@ static struct argp argp = {
 // Rank-dependent output streams established in main().
 static FILE *rankout, *rankerr;
 
+static void finalize_mpi(void)
+{
+    MPI_Finalize();
+}
+
 int main(int argc, char *argv[])
 {
     GRVY_TIMER_INIT(argp_program_version);
@@ -579,7 +584,7 @@ int main(int argc, char *argv[])
 
     // Initialize/finalize MPI
     MPI_Init(&argc, &argv);
-    atexit((void (*) ()) MPI_Finalize);
+    atexit(finalize_mpi);
     MPI_Comm_size(MPI_COMM_WORLD, &d.world_size);
     MPI_Comm_rank(MPI_COMM_WORLD, &d.world_rank);
 

--- a/apps/p3dfft_like.F90
+++ b/apps/p3dfft_like.F90
@@ -65,7 +65,7 @@ program p3dfft_like
   call initialize_problem(myid,numprocs)
 
   if (myid.eq.0) write(*,*) "initializing field:", ny, nz, nx, nc
-  call initialize_field(myid)
+  call initialize_field()
 
 ! Print domain decomposition details on each MPI rank
 ! do i = 0, numprocs - 1

--- a/apps/p3dfft_like_header.F90
+++ b/apps/p3dfft_like_header.F90
@@ -67,9 +67,9 @@ contains
 !! on each processor.  Global sizes are ny, nx, and nz.  Absolute
 !! coordinates are given by xist xien, zjst zjen, and 1 ny in the
 !! x, z, and y directions.
-  subroutine initialize_field(proc)
+  subroutine initialize_field()
 
-    integer(4) :: i,j,k,n,proc
+    integer(4) :: i,j,k,n
 
     !this loop is stride-1: u(ny,zjsz,xisz)
     do n=1,nc

--- a/esio/esio.F90
+++ b/esio/esio.F90
@@ -268,9 +268,9 @@ contains
     ! for details on MPI communicator interoperation
     interface
       function IMPL (comm) bind (C, name="esio_handle_initialize_fortran")
-        import :: esio_handle
-        type(esio_handle)          :: IMPL
-        integer, intent(in), value :: comm  ! Note integer not integer(c_int)
+        import :: esio_handle, c_int
+        type(esio_handle)              :: IMPL
+        integer(c_int), intent(in), value :: comm
       end function IMPL
     end interface
 

--- a/esio/restart-rename.c
+++ b/esio/restart-rename.c
@@ -250,7 +250,7 @@ int restart_rename(const char *src_filepath,
         // Construct the source pathname for any in-range entry
         if (0 > snprintf_realloc(&srcbuf, &srclen, "%s/%s",
                                  tmpl_dirname, namelist[n]->d_name)) {
-            snprintf(errmsg, sizeof(errmsg), "Unable to form srcbuf for '%s'",
+            snprintf(errmsg, sizeof(errmsg), "Unable to form srcbuf for '%.226s'",
                      namelist[n]->d_name);
             free(srcbuf);
             free(dstbuf);
@@ -263,7 +263,7 @@ int restart_rename(const char *src_filepath,
         // Construct the destination pathname from the template details
         if (0 > snprintf_realloc(&dstbuf, &dstlen, "%s/%s%0*d%s",
                                  tmpl_dirname, prefix, ndigits, next, suffix)) {
-            snprintf(errmsg, sizeof(errmsg), "Unable to form dstbuf for '%s'",
+            snprintf(errmsg, sizeof(errmsg), "Unable to form dstbuf for '%.226s'",
                      namelist[n]->d_name);
             free(srcbuf);
             free(dstbuf);

--- a/esio/x-plane.c
+++ b/esio/x-plane.c
@@ -42,7 +42,7 @@ int METHODNAME(hid_t plist_id, hid_t dset_id, QUALIFIER void *plane,
     const hsize_t nelems = blocal * bstride;
     const hsize_t lies   = 1;
     const hid_t memspace
-        = H5Screate_simple(1, blocal * alocal ? &nelems : &lies, NULL);
+        = H5Screate_simple(1, (blocal && alocal) ? &nelems : &lies, NULL);
     assert(memspace > 0);
     if (blocal * alocal == 0) {
         H5Sselect_none(memspace);

--- a/examples/concepts1.c
+++ b/examples/concepts1.c
@@ -2,10 +2,15 @@
 #include <mpi.h>
 #include <esio/esio.h>
 
+static void finalize_mpi(void)
+{
+    MPI_Finalize();
+}
+
 int main(int argc, char *argv[])
 {
     MPI_Init(&argc, &argv);
-    atexit((void (*) ()) MPI_Finalize);
+    atexit(finalize_mpi);
     int world_size, world_rank;
     MPI_Comm_size(MPI_COMM_WORLD, &world_size);
     MPI_Comm_rank(MPI_COMM_WORLD, &world_rank);

--- a/examples/restart1.c
+++ b/examples/restart1.c
@@ -2,11 +2,16 @@
 #include <mpi.h>
 #include <esio/esio.h>
 
+static void finalize_mpi(void)
+{
+    MPI_Finalize();
+}
+
 int main(int argc, char *argv[])
 {
     // Initialize MPI and arrange for its finalization
     MPI_Init(&argc, &argv);
-    atexit((void (*) ()) MPI_Finalize);
+    atexit(finalize_mpi);
     int world_size, world_rank;
     MPI_Comm_size(MPI_COMM_WORLD, &world_size);
     MPI_Comm_rank(MPI_COMM_WORLD, &world_rank);
@@ -16,7 +21,7 @@ int main(int argc, char *argv[])
         esio_handle s = esio_handle_initialize(MPI_COMM_SELF);
         esio_file_create(s, "template.h5", 1 /* overwrite */);
         esio_string_set(s, "/", "program", argv[0]);
-        esio_string_set(s, "/", "built",   __DATE__ " " __TIME__);
+        esio_string_set(s, "/", "built",   "ESIO example program");
         esio_handle_finalize(s);
     }
     MPI_Barrier(MPI_COMM_WORLD);  // Prevent template create/clone race

--- a/license.am
+++ b/license.am
@@ -2,11 +2,11 @@
 # Embedded license header support
 #---------------------------------
 
-CLEANFILES    += .license.stamp
-BUILT_SOURCES += .license.stamp
+CLEANFILES    += license.stamp
+BUILT_SOURCES += license.stamp
 
-.license.stamp: $(top_builddir)/LICENSE
-	rm -f .license.stamp
+license.stamp: $(top_builddir)/LICENSE
+	rm -f license.stamp
 	for file in $(wildcard $(srcdir)/*.[ch].in $(srcdir)/*.[ch]) ; do \
 		$(top_srcdir)/build-aux/update_license.pl $(top_builddir)/LICENSE $$file | tee -a $@ ;\
 	done


### PR DESCRIPTION
This PR addresses several compiler warnings and code quality issues across the codebase.

## Summary
Multiple fixes to improve code correctness and eliminate compiler warnings, including proper function pointer casting, buffer overflow prevention, logical operator corrections, and removal of unused parameters.

## Key Changes

- **MPI finalization**: Replace unsafe function pointer casts `(void (*) ()) MPI_Finalize` with proper wrapper functions `finalize_mpi()` in `esio_bench.c`, `concepts1.c`, and `restart1.c`. This eliminates compiler warnings about incompatible function pointer types.

- **Fortran parameter cleanup**: Remove unused `proc` parameter from `initialize_field()` subroutine in `p3dfft_like.F90` and `p3dfft_like_header.F90` to eliminate unused variable warnings.

- **Fortran interface fix**: Update `esio_handle_initialize` interface in `esio.F90` to properly declare `comm` parameter as `integer(c_int)` instead of plain `integer`, ensuring correct C interoperability.

- **Buffer overflow prevention**: Add format string length specifiers (`%.226s`) in `restart-rename.c` error messages to prevent potential buffer overflows when printing directory entry names.

- **Logical operator fix**: Change bitwise AND operator `*` to logical AND operator `&&` in `x-plane.c` for proper boolean expression evaluation.

- **Build system cleanup**: Rename `.license.stamp` to `license.stamp` in `license.am` to follow standard naming conventions and avoid hidden file issues.

- **Example program update**: Replace `__DATE__ " " __TIME__` macro expansion with static string `"ESIO example program"` in `restart1.c` for reproducible builds.

## Notable Details
These changes improve code robustness by fixing potential runtime issues (buffer overflows), eliminating compiler warnings that could mask real problems, and ensuring proper C/Fortran interoperability.