### PR TITLE
Add CircleCI configuration with automated docs deployment

### DIFF
--- a/.circleci/README.md
+++ b/.circleci/README.md
@@ -1,0 +1,61 @@
+# CircleCI Configuration
+
+This directory contains the CircleCI configuration for automated testing and
+documentation deployment.
+
+## Jobs
+
+### `distcheck`
+
+Builds and tests ESIO using the autotools distribution check. Installs HDF5
+(with MPI support) and gfortran from system packages, then runs the full
+autotools build: `bootstrap`, `configure`, `make distcheck`.
+
+### `deploy-docs`
+
+Builds Doxygen documentation then deploys it to the `gh-pages` branch on GitHub
+Pages.  This job only runs on the `master` branch after all tests pass.
+
+## GitHub Pages Deployment Setup
+
+To enable automatic documentation deployment, configure the following in your
+CircleCI project settings:
+
+### Required Environment Variables
+
+Add these environment variables in CircleCI Project Settings → Environment
+Variables:
+
+1. **GH_NAME**: Your GitHub username or bot name for commits
+   - Example: `CircleCI Documentation Bot`
+
+2. **GH_EMAIL**: Email address for documentation commits
+   - Example: `ci-bot@example.com`
+
+3. **GH_TOKEN**: GitHub Personal Access Token with `repo` scope
+   - Allows CircleCI to push to the `gh-pages` branch
+   - Create at: https://github.com/settings/tokens
+   - Required permissions: This repository only, Content, Read-Write
+
+### GitHub Repository Setup
+
+1. The `gh-pages` branch will be automatically created on first deployment
+
+2. After the first deployment, enable GitHub Pages in repository settings:
+   - Go to Settings → Pages
+   - Source: Deploy from a branch
+   - Branch: `gh-pages` / `root`
+
+3. Your documentation will be available at:
+   `https://RhysU.github.io/ESIO/`
+
+### Security Note
+
+The `GH_TOKEN` should be kept secret. Never commit it to the repository.
+CircleCI environment variables are encrypted and not exposed in build logs.
+
+## References
+
+- [CircleCI Environment Variables](https://circleci.com/docs/env-vars/)
+- [GitHub Personal Access Tokens](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)
+- [GitHub Pages Documentation](https://docs.github.com/en/pages)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,6 @@ version: 2.1
 jobs:
   distcheck:
     docker:
-      # Use Ubuntu-based image with build essentials
       - image: cimg/base:stable
 
     steps:
@@ -23,21 +22,57 @@ jobs:
           name: Configure
           command: ./configure
 
-      ## Running distcheck only covers these details and saves time
-      #- run:
-      #    name: Build
-      #    command: make all
-      #
-      #- run:
-      #    name: Run tests
-      #    command: make check
-
       - run:
           name: Distribution check
           command: make distcheck
 
+  deploy-docs:
+    docker:
+      - image: cimg/base:stable
+    resource_class: small
+    steps:
+      - checkout
+      - run:
+          name: Install Doxygen and Graphviz
+          command: |
+            sudo apt-get update -qq
+            sudo apt-get install -y doxygen graphviz
+      - run:
+          name: Build Doxygen documentation
+          command: |
+            PROJECT=ESIO \
+            VERSION=$(grep AC_INIT configure.ac | cut -d, -f2 | tr -d '[] ') \
+            DOCDIR=docs \
+            SRCDIR=. \
+            GENERATE_HTML=YES \
+            GENERATE_LATEX=NO \
+            GENERATE_RTF=NO \
+            GENERATE_MAN=NO \
+            GENERATE_XML=NO \
+            GENERATE_CHI=NO \
+            HAVE_DOT=YES \
+            DOT_PATH="" \
+            BUILDDATE="" \
+            BUILDHOST="" \
+            BUILDUSER="" \
+            doxygen doxygen/doxygen.cfg
+      - run:
+          name: Deploy to gh-pages
+          command: |
+            if [ "${CIRCLE_BRANCH}" = "master" ]; then
+              echo "Deploying documentation to gh-pages..."
+              ./.circleci/deploy-ghpages.sh docs/html
+            else
+              echo "Not master (current: ${CIRCLE_BRANCH}), skipping deployment"
+            fi
+
 workflows:
-  version: 2
-  distcheck:
+  build-and-deploy:
     jobs:
       - distcheck
+      - deploy-docs:
+          requires:
+            - distcheck
+          filters:
+            branches:
+              only: master

--- a/.circleci/deploy-ghpages.sh
+++ b/.circleci/deploy-ghpages.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Deploy documentation to gh-pages branch
+# Based on: https://github.com/DevProgress/onboarding/wiki/Using-Circle-CI-with-Github-Pages-for-Continuous-Delivery
+
+set -eu
+
+SOURCE_DIR="${1:-docs/html}"
+if [ ! -d "$SOURCE_DIR" ]; then
+    echo "Error: Source directory $SOURCE_DIR does not exist"
+    exit 1
+fi
+
+git config --global user.email "${GH_EMAIL}"
+git config --global user.name "${GH_NAME}"
+
+TEMP_DIR=$(mktemp -d)
+trap "rm -rf '$TEMP_DIR'" EXIT
+cd "$TEMP_DIR"
+
+git init -b gh-pages
+
+cp -R "${CIRCLE_WORKING_DIRECTORY}/${SOURCE_DIR}"/* .
+
+touch .nojekyll
+
+git add -A
+git commit -m "Deploy documentation to GitHub Pages [ci skip]
+
+Built from commit ${CIRCLE_SHA1} on branch ${CIRCLE_BRANCH}"
+
+git remote add origin "https://${GH_TOKEN}@github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}.git"
+
+echo "Pushing to gh-pages branch..."
+git push --force --quiet origin gh-pages > /dev/null 2>&1
+
+echo "Documentation deployed successfully to gh-pages"


### PR DESCRIPTION
## Summary
This PR adds CircleCI configuration to enable automated testing and documentation deployment for the ESIO project.

## Key Changes
- **CircleCI Configuration** (`.circleci/config.yml`):
  - Maintained existing `distcheck` job for automated testing with autotools
  - Added new `deploy-docs` job that builds Doxygen documentation and deploys to GitHub Pages
  - Created `build-and-deploy` workflow that runs tests first, then deploys docs on the `master` branch only
  - Removed commented-out build steps to clean up configuration

- **Deployment Script** (`.circleci/deploy-ghpages.sh`):
  - New bash script to handle pushing generated documentation to the `gh-pages` branch
  - Configures git with credentials from environment variables
  - Creates a temporary directory for the gh-pages commit to avoid polluting the main repository
  - Uses force push to update the gh-pages branch with latest documentation

- **Documentation** (`.circleci/README.md`):
  - Comprehensive guide for setting up GitHub Pages deployment
  - Instructions for required environment variables (`GH_NAME`, `GH_EMAIL`, `GH_TOKEN`)
  - GitHub repository configuration steps
  - Security notes about token management

## Implementation Details
- Documentation deployment only runs on the `master` branch after all tests pass
- Doxygen configuration is parameterized via environment variables for flexibility
- The deployment script uses a temporary directory and cleanup trap to maintain repository cleanliness
- GitHub token is kept secure through CircleCI's encrypted environment variables
- The `.nojekyll` file is created to prevent Jekyll processing on GitHub Pages

https://claude.ai/code/session_017rWWM4i5VEsvzhBiXFK6Na